### PR TITLE
Nccos

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ downloader = LabeledDataDownloader(
     frac=1.0,  
     dataset_name="your_dataset_name",  # Output Directory Name
     output_dir="path/to/output",
-    label_field="your_label_field"  # "ScientificName"
+    label_field="your_label_field",  # "ScientificName", "Label", etc
+    task="detect"  # Only keep bounding boxes, even if polygons ("segment")
 )
 
 # Download the data and create the dataset

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -12,7 +12,15 @@
     "import fiftyone as fo\n",
     "\n",
     "from benthic_mapping.download_media import MediaDownloader\n",
-    "from benthic_mapping.fiftyone_clustering import FiftyOneDatasetViewer"
+    "from benthic_mapping.fiftyone_clustering import FiftyOneDatasetViewer\n",
+    "from benthic_mapping.download_labeled_data import LabeledDataDownloader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download Media (frames) from Tator"
    ]
   },
   {
@@ -79,6 +87,13 @@
    ],
    "source": [
     "downloader.media_path_map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# View Clustered Frames from Tator using Fiftyone"
    ]
   },
   {
@@ -218,6 +233,118 @@
     "    session = fo.launch_app(viewer.dataset)\n",
     "except:\n",
     "    session = fo.launch_app(viewer.dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download Labeled Data from Tator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters\n",
+    "api_token = os.getenv(\"TATOR_TOKEN\")\n",
+    "project_id = 155  # 70\n",
+    "\n",
+    "# Search string comes from Tator's Data Metadata Export utility\n",
+    "search_string = \"eyJtZXRob2QiOiJBTkQiLCJvcGVyYXRpb25zIjpbeyJhdHRyaWJ1dGUiOiIkY3JlYXRlZF9ieSIsIm9wZXJhdGlvbiI6ImVxIiwiaW52ZXJzZSI6ZmFsc2UsInZhbHVlIjo1MDZ9LHsibWV0aG9kIjoiT1IiLCJvcGVyYXRpb25zIjpbeyJhdHRyaWJ1dGUiOiIkdHlwZSIsIm9wZXJhdGlvbiI6ImVxIiwiaW52ZXJzZSI6ZmFsc2UsInZhbHVlIjo0NjB9LHsiYXR0cmlidXRlIjoiJHR5cGUiLCJvcGVyYXRpb24iOiJlcSIsImludmVyc2UiOmZhbHNlLCJ2YWx1ZSI6NTUzfV19XX0=\"\n",
+    "\n",
+    "# Demo for downloading labeled data\n",
+    "frac = 0.1\n",
+    "\n",
+    "dataset_name = \"benthic_demo\"\n",
+    "output_dir = \"../Data/Labeled_Data\"\n",
+    "\n",
+    "label_field = \"Label\"\n",
+    "task = \"detect\"  # \"detect\" for bboxes or \"segment\" for polygons (if applicable)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: Authentication successful for jordan.pierce\n",
+      "NOTE: Search string saved to e:\\Benthic-Mapping\\Data\\Labeled_Data\\benthic_demo\\search_string.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a downloader for the labeled data\n",
+    "downloader = LabeledDataDownloader(api_token,\n",
+    "                                   project_id=project_id,\n",
+    "                                   search_string=search_string,\n",
+    "                                   frac=frac,\n",
+    "                                   output_dir=output_dir,\n",
+    "                                   dataset_name=dataset_name,\n",
+    "                                   label_field=label_field,\n",
+    "                                   task=task)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: Querying Tator for labeled data\n",
+      "NOTE: Found 8645 localizations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Processing Query: 100%|██████████| 8645/8645 [00:00<00:00, 11541.39it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: Found 904 localizations after sampling\n",
+      "NOTE: Data saved to e:\\Benthic-Mapping\\Data\\Labeled_Data\\benthic_demo\\data.json\n",
+      "NOTE: Downloading images to e:\\Benthic-Mapping\\Data\\Labeled_Data\\benthic_demo\\images\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Downloading images: 100%|██████████| 20/20 [00:24<00:00,  1.22s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: Images downloaded to e:\\Benthic-Mapping\\Data\\Labeled_Data\\benthic_demo\\images\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Download the labeled data\n",
+    "downloader.download_data()"
    ]
   },
   {


### PR DESCRIPTION
This pull request includes several changes to the `benthic_mapping` module and its associated files to enhance functionality and improve code structure. The most important changes include refactoring the `LabeledDataDownloader` class, updating the `main` function, and modifying the `example.ipynb` notebook.

Enhancements to `LabeledDataDownloader` class:

* Added a new parameter `task` to the `LabeledDataDownloader` class to specify the type of task (detecting bounding boxes or segmenting polygons). (`[benthic_mapping/download_labeled_data.pyL25-R32](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dL25-R32)`)
* Refactored the `process_query` method to handle both bounding boxes and polygons and to save data to a JSON file. (`[[1]](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dR124-R129)`, `[[2]](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dL123-R164)`, `[[3]](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dL144-R275)`)
* Improved the `download_images` method to use multithreading for downloading images and added retry logic. (`[benthic_mapping/download_labeled_data.pyL1-R17](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dL1-R17)71R296`)
* Added a new method `query_tator` to handle querying TATOR for data. (`[benthic_mapping/download_labeled_data.pyL96-R114](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dL96-R114)`)

Updates to `main` function:

* Updated the `main` function to include the new `task` parameter and convert `output_dir` to an absolute path. (`[benthic_mapping/download_labeled_data.pyR299-R316](diffhunk://#diff-3adece88206afa0d50059ec6ee3bd70c26e7c7fc9a0db540b0f2d6359342f93dR299-R316)`)

Modifications to `example.ipynb` notebook:

* Added sections to demonstrate downloading labeled data from Tator using the `LabeledDataDownloader` class. (`[[1]](diffhunk://#diff-925a234c483df495c7625c4a2319f6ca4d206d61a4b16fe98d38a9e1498713aaL15-R23)`, `[[2]](diffhunk://#diff-925a234c483df495c7625c4a2319f6ca4d206d61a4b16fe98d38a9e1498713aaR92-R98)`, `[[3]](diffhunk://#diff-925a234c483df495c7625c4a2319f6ca4d206d61a4b16fe98d38a9e1498713aaR238-R349)`)